### PR TITLE
add delay option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,8 @@ func init() {
 
 	rootCmd.Flags().IntP("max-concurrency", "m", 1000, "max concurrent tasks / ex: -m 10")
 
+	rootCmd.Flags().IntP("delay", "d", 0, "delay between each request in each task in milliseconds / ex: -d 200")
+
 	rootCmd.Flags().StringP("proxy", "p", "", "proxy to use / ex: -p http://proxy.com:8080")
 
 	rootCmd.Flags().IntP("timeout", "t", 10, "timeout in seconds / ex: -t 10")

--- a/core/crawler.go
+++ b/core/crawler.go
@@ -83,6 +83,7 @@ type Crawler struct {
 	UserAgent      string
 	Cache          Cache
 	MaxConcurrency int
+	Delay          int
 }
 
 func NewCrawler(options *shared.Options) *Crawler {
@@ -95,6 +96,7 @@ func NewCrawler(options *shared.Options) *Crawler {
 		ExcludedStatus: options.StatusResponses,
 		IncludedUrls:   options.IncludedUrls,
 		MaxConcurrency: options.MaxConcurrency,
+		Delay:          options.Delay,
 		UserAgent:      options.UserAgent,
 		Cache: Cache{
 			Visited: make(map[string]bool),
@@ -142,6 +144,10 @@ func (c *Crawler) Fetch(page *webtree.Page) {
 	}
 	page.SetData(string(body))
 	page.SetStatusCode(resp.StatusCode)
+
+	if c.Delay > 0 {
+		time.Sleep(time.Duration(c.Delay) * time.Millisecond)
+	}
 }
 
 func (c *Crawler) ExtractLinks(page *webtree.Page) (links []string) {

--- a/shared/options.go
+++ b/shared/options.go
@@ -21,6 +21,7 @@ type Options struct {
 	StatusResponses []int             `name:"exclude codes"`
 	IncludedUrls    []string          `name:"include"`
 	MaxConcurrency  int               `name:"max concurrency"`
+	Delay           int               `name:"delay"`
 	Proxy           *urlTool.URL      `name:"proxy"`
 	TimeOut         int               `name:"timeout"`
 	UserAgent       string            `name:"user agent"`
@@ -202,6 +203,11 @@ func ValidateThenBuildOption(cmd *cobra.Command) (*Options, error) {
 		return nil, err
 	}
 
+	delay, err := cmd.Flags().GetInt("delay")
+	if err != nil {
+		return nil, err
+	}
+
 	proxy, err := cmd.Flags().GetString("proxy")
 	if err != nil {
 		return nil, err
@@ -266,6 +272,7 @@ func ValidateThenBuildOption(cmd *cobra.Command) (*Options, error) {
 		StatusResponses: excludedStatus,
 		IncludedUrls:    includedUrls,
 		MaxConcurrency:  maxConcurrency,
+		Delay:           delay,
 		Proxy:           parsedProxy,
 		TimeOut:         timeout,
 		UserAgent:       userAgentString,


### PR DESCRIPTION
Adds an option `-d` to specify the number of milliseconds to pause between each request, per task.  
My own use-case is to reduce load on a site I'm crawling for cache warming, but also useful to prevent app/WAF rate-limiting.