### PR TITLE
update cache type: make map of empty struct

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -3,7 +3,7 @@ package core
 import "sync"
 
 type Cache struct {
-	Visited map[string]bool
+	Visited map[string]struct{}
 	Lock    sync.Mutex
 }
 
@@ -17,11 +17,11 @@ func (c *Cache) IsVisited(url string) bool {
 func (c *Cache) AddVisited(url string) {
 	c.Lock.Lock()
 	defer c.Lock.Unlock()
-	c.Visited[url] = true
+	c.Visited[url] = struct{}{}
 }
 
 func (c *Cache) Flush() {
 	c.Lock.Lock()
 	defer c.Lock.Unlock()
-	c.Visited = make(map[string]bool)
+	c.Visited = make(map[string]struct{})
 }

--- a/core/crawler.go
+++ b/core/crawler.go
@@ -98,7 +98,7 @@ func NewCrawler(options *shared.Options) *Crawler {
 		Delay:          options.Delay,
 		UserAgent:      options.UserAgent,
 		Cache: Cache{
-			Visited: make(map[string]bool),
+			Visited: make(map[string]struct{}),
 		},
 	}
 	transport := &http.Transport{

--- a/core/tests/cache_test.go
+++ b/core/tests/cache_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCache(t *testing.T) {
-	cache := core.Cache{Visited: make(map[string]bool)}
+	cache := core.Cache{Visited: make(map[string]struct{})}
 	url := "http://example.com"
 
 	// Add the URL to the cache

--- a/core/tests/core_test.go
+++ b/core/tests/core_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCache_AddAndIsVisited(t *testing.T) {
-	cache := core.Cache{Visited: make(map[string]bool)}
+	cache := core.Cache{Visited: make(map[string]struct{})}
 	url := "http://example.com"
 
 	// Initially, the URL should not be marked as visited


### PR DESCRIPTION
this PR updates the Cache struct.
it specifically updates the type of the type of the `Visited` field to `map[string]struct{}` to save more memory.
in this case (in the Cache type), we don't care about the value type, we just need to store values in the cache, and check later if exist, and possibly retrieve them (retrieve the key), hence, we need to minimize the size of the value as much as possible in order to save memory, and the correct type for this in Go is the empty struct.

the size of a variable of type `bool` is: 1 byte.
the size of empty struct is 0 bytes, since the size of the struct is equal to the sum of the sizes of its fields, and an empty struct has no fields, hence, 0 bytes...

so if the cache become large, the `Visited` map will store additional unneeded bytes.
ex: a cache instance that holds 1_000_000 entries in the `Visited` map
this means that `1_000_000` bytes are used by our program in the time that we don't need them.

Though modern computers offer substantial RAM capacities, optimizing memory usage remains a crucial practice